### PR TITLE
:wrench: move install script test from nxxm-src to nxxm releases repository

### DIFF
--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -1,0 +1,36 @@
+name: check_install_script
+on:
+  schedule:
+    - cron : '0 0 * * *' # Every midnight check the released version of default branch
+  pull_request:
+  
+
+jobs:
+  install-macos:
+    name: install-macos
+    runs-on: macos-latest
+    steps:
+      - name: test_install_on_macos
+        run: |
+          script_source=${GITHUB_REF#refs/heads/}
+          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+        
+
+  install-linux:
+    name: install-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: test_install_on_linux
+        run: |
+          script_source=${GITHUB_REF#refs/heads/}
+          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+
+  install-windows-powershell:
+    name: install-windows-powershell
+    runs-on: windows-latest
+    steps:
+      - name: test_install_on_windows_powershell
+        run: |
+         $script_source=$env:GITHUB_REF.replace('refs/heads/', '')
+         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
+        shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -58,7 +58,6 @@ jobs:
           Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
 
           # Test install succeeeded 
-          if (!(Test-Path "C:\\Windows\\nxxm.exe" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "C:\\ProgramData\\nxxm\\nxxm.exe" -PathType leaf)) { exit 1; }
           if (!(Test-Path "C:\\.nxxm\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
-          if (!(Test-Path "C:\ProgramData\install_nxxm\\wasm-cxx17\\bin\\installdeps.js" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -50,7 +50,6 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
-          mkdir -Force D:\a\.nxxm\
           $env:NXXM_HOME_DIR = "D:\a\.nxxm"
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
             $script_source = $env:GITHUB_HEAD_REF.replace('refs/heads/', '')

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -21,7 +21,7 @@ jobs:
 
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxm/0000001/downloads/nodejs.zip
+          test -f ~/.nxxm/0000002/downloads/nodejs.zip
           test -f /tmp/install_nxxm/build/wasm-cxx17/bin/installdeps.js
           
 
@@ -41,7 +41,7 @@ jobs:
           
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxm/0000001/downloads/nodejs.zip
+          test -f ~/.nxxm/0000002/downloads/nodejs.zip
           test -f /tmp/install_nxxm/build/wasm-cxx17/bin/installdeps.js
 
   install-windows-powershell:

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -22,6 +22,7 @@ jobs:
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
           test -f ~/.nxxm/0000001/downloads/nodejs.zip
+          test -f /tmp/install_nxxm/build/wasm-cxx17/bin/installdeps.js
           
 
   install-linux:
@@ -41,6 +42,7 @@ jobs:
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
           test -f ~/.nxxm/0000001/downloads/nodejs.zip
+          test -f /tmp/install_nxxm/build/wasm-cxx17/bin/installdeps.js
 
   install-windows-powershell:
     name: install-windows-powershell
@@ -58,4 +60,5 @@ jobs:
           # Test install succeeeded 
           if (!(Test-Path "C:\\Windows\\nxxm.exe" -PathType leaf)) { exit 1; }
           if (!(Test-Path "C:\\.nxxm\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "C:\ProgramData\install_nxxm\\wasm-cxx17\\bin\\installdeps.js" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -61,5 +61,5 @@ jobs:
 
           # Test install succeeeded 
           if (!(Test-Path "C:\\ProgramData\\nxxm\\nxxm.exe" -PathType leaf)) { exit 1; }
-          if (!(Test-Path "$env:NXXM_HOME_DIR\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "$env:NXXM_HOME_DIR\\0000002\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -56,7 +56,7 @@ jobs:
           } else {
             $script_source = $env:GITHUB_REF.replace('refs/heads/', '')
           }
-          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
+          . { iwr -useb https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1 } | iex 
 
           # Test install succeeeded 
           if (!(Test-Path "C:\\ProgramData\\nxxm\\nxxm.exe" -PathType leaf)) { exit 1; }

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
-          $env:NXXM_HOME_DIR = "D:\a\.nxxm"
+          $env:NXXM_HOME_DIR = "C:\.nxxm"
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
             $script_source = $env:GITHUB_HEAD_REF.replace('refs/heads/', '')
           } else {

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
+          $env:NXXM_HOME_DIR = "D:\\a\\.nxxm"
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
             $script_source = $env:GITHUB_HEAD_REF.replace('refs/heads/', '')
           } else {
@@ -59,5 +60,5 @@ jobs:
 
           # Test install succeeeded 
           if (!(Test-Path "C:\\ProgramData\\nxxm\\nxxm.exe" -PathType leaf)) { exit 1; }
-          if (!(Test-Path "C:\\.nxxm\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "$env:NXXM_HOME_DIR\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -1,6 +1,8 @@
 name: check_install_script
 on:
   push:
+    branches:
+      - master
     - master
   schedule:
     - cron : '0 0 * * *' # Every midnight check the released version of default branch

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -36,7 +36,6 @@ jobs:
             script_source=${GITHUB_REF#refs/heads/}
           fi
           echo "Script source : ${script_source}"
-          ${github.payload.pull_request.head.ref}
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
           
           # Test install succeeeded 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -50,7 +50,8 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
-          $env:NXXM_HOME_DIR = "D:\\a\\.nxxm"
+          mkdir -Force D:\a\.nxxm\
+          $env:NXXM_HOME_DIR = "D:\a\.nxxm"
           if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
             $script_source = $env:GITHUB_HEAD_REF.replace('refs/heads/', '')
           } else {

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: test_install_on_linux
         run: |
           if [ $GITHUB_EVENT_NAME = "pull_request" ]; then
-            script_source=${github.payload.pull_request.head.ref}
+            script_source=${GITHUB_HEAD_REF}
           else 
             script_source=${GITHUB_REF#refs/heads/}
           fi

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -12,10 +12,13 @@ jobs:
     steps:
       - name: test_install_on_macos
         run: |
-          set -e
           script_source=${GITHUB_REF#refs/heads/}
-          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
-        
+          sudo -E /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+
+          # Test install succeeeded 
+          test -f /usr/local/bin/nxxm
+          test -f ~/.nxxxm/0000002/downloads/nodejs.zip
+          
 
   install-linux:
     name: install-linux
@@ -23,9 +26,12 @@ jobs:
     steps:
       - name: test_install_on_linux
         run: |
-          set -e
           script_source=${GITHUB_REF#refs/heads/}
-          sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+          sudo -E /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+          
+          # Test install succeeeded 
+          test -f /usr/local/bin/nxxm
+          test -f ~/.nxxxm/0000002/downloads/nodejs.zip
 
   install-windows-powershell:
     name: install-windows-powershell
@@ -33,6 +39,10 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
-         $script_source=$env:GITHUB_REF.replace('refs/heads/', '')
-         Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
+          $script_source=$env:GITHUB_REF.replace('refs/heads/', '')
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
+
+          # Test install succeeeded 
+          if (!(Test-Path "C:\\Windows\\nxxm.exe" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "C:\\.nxxm\\0000002\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-    - master
   schedule:
     - cron : '0 0 * * *' # Every midnight check the released version of default branch
   pull_request:

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -12,7 +12,11 @@ jobs:
     steps:
       - name: test_install_on_macos
         run: |
-          export script_source=${GITHUB_REF#refs/heads/}
+          if [ $GITHUB_EVENT_NAME = "pull_request" ]; then
+            script_source=${GITHUB_HEAD_REF}
+          else 
+            script_source=${GITHUB_REF#refs/heads/}
+          fi
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
 
           # Test install succeeeded 
@@ -26,8 +30,13 @@ jobs:
     steps:
       - name: test_install_on_linux
         run: |
-          export script_source=${GITHUB_REF#refs/heads/}
+          if [ $GITHUB_EVENT_NAME = "pull_request" ]; then
+            script_source=${github.payload.pull_request.head.ref}
+          else 
+            script_source=${GITHUB_REF#refs/heads/}
+          fi
           echo "Script source : ${script_source}"
+          ${github.payload.pull_request.head.ref}
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
           
           # Test install succeeeded 
@@ -40,7 +49,11 @@ jobs:
     steps:
       - name: test_install_on_windows_powershell
         run: |
-          $script_source=$env:GITHUB_REF.replace('refs/heads/', '')
+          if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
+            $script_source = $env:GITHUB_HEAD_REF.replace('refs/heads/', '')
+          } else {
+            $script_source = $env:GITHUB_REF.replace('refs/heads/', '')
+          }
           Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/nxxm/nxxm/$script_source/install/install_for_windows.ps1"))
 
           # Test install succeeeded 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -1,5 +1,7 @@
 name: check_install_script
 on:
+  push:
+    - master
   schedule:
     - cron : '0 0 * * *' # Every midnight check the released version of default branch
   pull_request:

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: test_install_on_macos
         run: |
+          set -e
           script_source=${GITHUB_REF#refs/heads/}
           sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
         
@@ -22,6 +23,7 @@ jobs:
     steps:
       - name: test_install_on_linux
         run: |
+          set -e
           script_source=${GITHUB_REF#refs/heads/}
           sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -21,7 +21,7 @@ jobs:
 
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxxm/0000001/downloads/nodejs.zip
+          test -f ~/.nxxm/0000001/downloads/nodejs.zip
           
 
   install-linux:
@@ -40,7 +40,7 @@ jobs:
           
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxxm/0000001/downloads/nodejs.zip
+          test -f ~/.nxxm/0000001/downloads/nodejs.zip
 
   install-windows-powershell:
     name: install-windows-powershell
@@ -57,5 +57,5 @@ jobs:
 
           # Test install succeeeded 
           if (!(Test-Path "C:\\Windows\\nxxm.exe" -PathType leaf)) { exit 1; }
-          if (!(Test-Path "C:\\.nxxm\\0000002\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
+          if (!(Test-Path "C:\\.nxxm\\0000001\\downloads\\nodejs.zip" -PathType leaf)) { exit 1; }
         shell: powershell 

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - name: test_install_on_macos
         run: |
-          script_source=${GITHUB_REF#refs/heads/}
-          sudo -E /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+          export script_source=${GITHUB_REF#refs/heads/}
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
 
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
@@ -26,8 +26,9 @@ jobs:
     steps:
       - name: test_install_on_linux
         run: |
-          script_source=${GITHUB_REF#refs/heads/}
-          sudo -E /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
+          export script_source=${GITHUB_REF#refs/heads/}
+          echo "Script source : ${script_source}"
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nxxm/nxxm/${script_source}/install/install_for_macos_linux.sh)"
           
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm

--- a/.github/workflows/check_install_script.yaml
+++ b/.github/workflows/check_install_script.yaml
@@ -21,7 +21,7 @@ jobs:
 
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxxm/0000002/downloads/nodejs.zip
+          test -f ~/.nxxxm/0000001/downloads/nodejs.zip
           
 
   install-linux:
@@ -40,7 +40,7 @@ jobs:
           
           # Test install succeeeded 
           test -f /usr/local/bin/nxxm
-          test -f ~/.nxxxm/0000002/downloads/nodejs.zip
+          test -f ~/.nxxxm/0000001/downloads/nodejs.zip
 
   install-windows-powershell:
     name: install-windows-powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v0.0.9 - codename **far west** 
 
-## v0.0.9 - codename **far west** 
-
 ### Features
   * `nxxm ci` automatically generates a docker enabled Github Action to build C & C++ code
   * Configurable Build engines via `build_engines_mapping.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # nxxm : CHANGELOG
 
+## v0.0.9 - codename **far west** 
+
+### Features
+  * `nxxm ci` automatically generates a docker enabled Github Action to build C & C++ code
+  * Configurable Build engines via `build_engines_mapping.json`
+  * Simplified the nxxm installation process thanks to the one liner install scripts now available
+  * Support for macOS Big Sur
+  * Default NodeJS included is 14.7.0
+  * Default CMake included is 3.18.4
+  * Possibility to specify `NXXM_HOME_DIR` on the environment, to specify the main nxxm download and build cache location ( _c.f._  [NXXM\_HOME\_DIR Documentation](https://nxxm-docs.readthedocs.io/en/latest/09-Dependencies_nxxm.html)
+  * Build with Visual Studio 16 2019 MSVC via `nxxm . -t vs-16-2019-win64-cxx17`
+
+### Bug fixes
+  * Perl is now shipped by nxxm on Windows to accomodate special build processes including OpenSSL
+  * Now multiple .cpp files at the top-level folder of an application project ( one with a main() and others without function) work.
+  * Fixed build recipe generation for projects in different directories that current nxxm working directory
+  * Fix host & cross compiling Boost on Windows
+  * Now after 5 downloads retries, nxxm refuses to continue if the SHA1 checksum isn't correct. Precedent version would use the incorrect file.
+  * Command line flags `--dont-upgrade, --force-upgrade, --auto-upgrade` can now be passed without any complaints from the options parser, to control nxxm auto-update feature.
+  * Improved drastically the test suite to handle build corner cases found at our customers
+
+### Known issues
+  - Compiling a project by providing a relative path to it : `nxxm relative/path/to-project` doesn't work. `nxxm .` inside the folder of the project works. 
+
 ## ALPHA v0.0.8 
 ### Features
 * Webassembly builds with wasm threads, emscripten 1.39.5 & NodeJS v14.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.0.9 - codename **far west** 
 
+## v0.0.9 - codename **far west** 
+
 ### Features
   * `nxxm ci` automatically generates a docker enabled Github Action to build C & C++ code
   * Configurable Build engines via `build_engines_mapping.json`
@@ -23,6 +25,12 @@
 
 ### Known issues
   - Compiling a project by providing a relative path to it : `nxxm relative/path/to-project` doesn't work. `nxxm .` inside the folder of the project works. 
+  - Compiling a project that is stored in a Path where a folder has a space in the name  doesn't work
+
+##### Archives Checksums
+nxxm-v0.0.9-linux-x86_64.zip:FE64B5D4DC96FA39BAA97659FAF6CB8F5C25031A
+nxxm-v0.0.9-macOS.zip:91A47E79132B173CF2BB176A4E6693FAC8B48FCA
+nxxm-v0.0.9-windows-win64.zip:308252401C2467F850611C9336782F5E28215EA1
 
 ## ALPHA v0.0.8 
 ### Features

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018-present nxxm project (https://nxxm.github.io/)
+Copyright (c) 2020 nxxm project (https://nxxm.github.io/)
 
 Proprietary. All Rights Reserved. Provided As Is Without any Warranty of any kind.
 

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -28,7 +28,7 @@ should_install_unzip() {
 if should_install_unzip; then
     info "unzip is needed to unzip the downloaded file, we are installing unzip with your package manager"
     echo "Could you validate with your password ? 😇 "
-    sudo apt-get install unzip -y ||   abort "Error while installing unzip"
+    sudo apt-get install unzip -y || abort "Error while installing unzip"
 fi
 
 info "Downloading nxxm..."
@@ -38,7 +38,7 @@ sudo unzip ~/nxxm.zip -d $INSTALL_FOLDER -x LICENSE && rm ~/nxxm.zip
 
 if [ $? -eq 0 ]; then
     info "nxxm successfully installed. Installing the dependencies..."
-    mkdir /tmp/install_nxxm && echo "#include <iostream> int main(){return 0;}">> ~/install_nxxm/installdeps.cpp
+    mkdir /tmp/install_nxxm && echo "#include <iostream> int main(){return 0;}">> /tmp/install_nxxm/installdeps.cpp
     $INSTALL_FOLDER/bin/nxxm /tmp/install_nxxm
     if [ $? -eq 0 ]; then
         info "nxxm and its dependencies have been successfully installed"

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ "$(uname)" == "Linux" ]; then
-  NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.8-linux-x86_64.zip"
+  NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.9/nxxm-v0.0.9-linux-x86_64.zip"
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
-  NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.8-macOS.zip"
+  NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.9/nxxm-v0.0.9-macOS.zip"
 fi
 
 INSTALL_FOLDER="/usr/local"

--- a/install/install_for_macos_linux.sh
+++ b/install/install_for_macos_linux.sh
@@ -26,22 +26,22 @@ should_install_unzip() {
 }
 
 if should_install_unzip; then
-    info "unzip is needed to unzip the downloaded file, we are installing it with your package manager"
+    info "unzip is needed to unzip the downloaded file, we are installing unzip with your package manager"
     echo "Could you validate with your password ? 😇 "
     sudo apt-get install unzip -y ||   abort "Error while installing unzip"
 fi
 
 info "Downloading nxxm..."
 curl -fSL $NXXM_URL --output ~/nxxm.zip || wget -q $NXXM_URL -O ~/nxxm.zip || abort "Could not download nxxm"
-info "Installing nxxm in  $INSTALL_FOLDER/bin"
+info "Installing nxxm in $INSTALL_FOLDER/bin"
 sudo unzip ~/nxxm.zip -d $INSTALL_FOLDER -x LICENSE && rm ~/nxxm.zip
 
 if [ $? -eq 0 ]; then
-    info "Nxxm successfully installed. Installing the dependencies..."
-    mkdir ~/install_nxxm && echo "#include <iostream> int main(){return 0;}">> ~/install_nxxm/installdeps.cpp
-    $INSTALL_FOLDER/bin/nxxm ~/install_nxxm
+    info "nxxm successfully installed. Installing the dependencies..."
+    mkdir /tmp/install_nxxm && echo "#include <iostream> int main(){return 0;}">> ~/install_nxxm/installdeps.cpp
+    $INSTALL_FOLDER/bin/nxxm /tmp/install_nxxm
     if [ $? -eq 0 ]; then
-        info "Nxxm and its dependencies have been successfully installed"
+        info "nxxm and its dependencies have been successfully installed"
     else 
         abort "Error while installing the dependencies"
     fi

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -1,5 +1,5 @@
 $INSTALL_FOLDER="C:\ProgramData\nxxm"
-$NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.8-windows-win64.zip"
+$NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.9-windows-win64.zip"
 $NXXM_EXE="$INSTALL_FOLDER\nxxm.exe"
 
 $texte = '#include <iostream>

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -1,6 +1,4 @@
-﻿﻿#!/usr/bin/pwsh
-
-$INSTALL_FOLDER="C:\Windows"
+﻿$INSTALL_FOLDER="C:\Windows"
 $NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.8-windows-win64.zip"
 $NXXM_EXE="C:\Windows\nxxm.exe"
 $INSTALL_FORDEPS = "C:\ProgramData\install_nxxm"

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -45,7 +45,7 @@ if (!$?){
 }
 rm -R ~/nxxm
 
-info "Nxxm is setting up its dependencies"
+info "nxxm is setting up its dependencies"
 New-Item -ItemType "file" -Path $INSTALL_FORDEPS"\installdeps.cpp" -Force
 add-content $INSTALL_FORDEPS"\installdeps.cpp" $texte
 
@@ -59,7 +59,7 @@ Do {
 } while ($objExec.StdOut.AtEndOfStream -ne $true)
    
 if ($?){
-    info "Nxxm and its dependencies have been successfully installed"
+    info "nxxm and its dependencies have been successfully installed"
     rm -R $INSTALL_FORDEPS
 }else{
     rm - $INSTALL_FORDEPS

--- a/install/install_for_windows.ps1
+++ b/install/install_for_windows.ps1
@@ -1,5 +1,5 @@
 $INSTALL_FOLDER="C:\ProgramData\nxxm"
-$NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.8/nxxm-v0.0.9-windows-win64.zip"
+$NXXM_URL="https://github.com/nxxm/nxxm/releases/download/v0.0.9/nxxm-v0.0.9-windows-win64.zip"
 $NXXM_EXE="$INSTALL_FOLDER\nxxm.exe"
 
 $texte = '#include <iostream>


### PR DESCRIPTION
Dear @amri04 @Lambourl  

Just a PR to let you notice I moved CI workflows for tests scripts out of nxxm-src and fixed the install folder to use /tmp and not $HOME, as it makes no sense to pollute user's home.